### PR TITLE
Refactor: 구직 페이지 - 환자 프로필 컴포넌트화

### DIFF
--- a/src/components/JobCard.jsx
+++ b/src/components/JobCard.jsx
@@ -1,0 +1,31 @@
+import { useNavigate } from 'react-router-dom';
+import userOrange from '../img/user_orange.png';
+import linkImg from "../img/link.png"
+
+
+function JobCard({index, id, title, author, name, license, affiliation, location }) {
+    const navigate = useNavigate();
+
+    return (
+        <div
+            key={index}
+            className='jobCard'
+            onClick={() => navigate(`/job/${id}`)}
+        >
+            <div className='cardContent'>
+                <img src={userOrange} alt="user" className='userIcon' />
+                <div className='cardText'>
+                    <h2>{title}</h2>
+                    <p>작성자: {author}</p>
+                    <p>단위: {name}</p>
+                    <p>자격증: {license}</p>
+                    <p>소속: {affiliation}</p>
+                    <p>지역: {location}</p>
+                </div>
+                <img className='linkImg' src={linkImg} alt="link" />
+            </div>
+        </div>
+    )
+}
+
+export default JobCard;

--- a/src/components/Patient.jsx
+++ b/src/components/Patient.jsx
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+import { Link, Route, BrowserRouter as Router, Routes } from 'react-router-dom'
+import profileImg from "../img/profile.png"
+import userOrange from '../img/user_orange.png';
+import linkImg from "../img/link.png"
+
+
+function Patient({ 
+                    id,
+                    name,
+                    age,
+                    height,
+                    weight,
+                    gender,
+                    careLocation,
+                    carePeriod,
+                    diagnosis,
+                    hospitalizationPurpose,
+                    roomType,
+                    mobilityStatus,
+                    assistiveDevices,
+                    medications
+                }) {
+
+    return (
+        <div className="detailCard">
+            <div className="userHeader">
+                <img src={userOrange} alt="user" className="userIcon" />
+                <div className="userInfo">
+                    <h2>{name} 환자</h2>
+                    <div className="userAttributes">
+                        <p><strong>나이:</strong> {age}세</p>
+                        <p><strong>키:</strong> {height}cm</p>
+                        <p><strong>몸무게:</strong> {weight}kg</p>
+                        <p><strong>성별:</strong> {gender}</p>
+                        <p><strong>간병 장소:</strong> {careLocation}</p>
+                    </div>
+                </div>
+            </div>
+            <div className="detailInfo">
+                <h3>세부 정보</h3>
+                <p><strong>요구 간병 기간:</strong> {carePeriod}</p>
+                <p><strong>진단명:</strong> {diagnosis}</p>
+                <p><strong>입원 목적:</strong> {hospitalizationPurpose}</p>
+                <p><strong>병실 유형:</strong> {roomType}</p>
+                <p><strong>거동 상태:</strong> {mobilityStatus}</p>
+                <p><strong>보조 장치 여부:</strong> {assistiveDevices}</p>
+                <p><strong>복용 약:</strong> {medications}</p>
+            </div>
+        </div>
+    )
+}
+
+export default Patient;

--- a/src/pages/JobDetailPage.jsx
+++ b/src/pages/JobDetailPage.jsx
@@ -1,7 +1,8 @@
 import { useParams } from 'react-router-dom';
 import "../style/JobDetailPage.css"; 
-import userOrange from '../img/user_orange.png'; 
+import Patient from '../components/Patient';
 
+// db에 구현
 const jobDetails = [
   {
     id: 1,
@@ -56,31 +57,22 @@ function JobDetailPage() {
 
   return (
     <div className="jobDetailPage">
-      <div className="detailCard">
-        <div className="userHeader">
-          <img src={userOrange} alt="user" className="userIcon" />
-          <div className="userInfo">
-            <h2>{jobDetail.name} 환자</h2>
-            <div className="userAttributes">
-              <p><strong>나이:</strong> {jobDetail.age}세</p>
-              <p><strong>키:</strong> {jobDetail.height}cm</p>
-              <p><strong>몸무게:</strong> {jobDetail.weight}kg</p>
-              <p><strong>성별:</strong> {jobDetail.gender}</p>
-              <p><strong>간병 장소:</strong> {jobDetail.careLocation}</p>
-            </div>
-          </div>
-        </div>
-        <div className="detailInfo">
-          <h3>세부 정보</h3>
-          <p><strong>요구 간병 기간:</strong> {jobDetail.carePeriod}</p>
-          <p><strong>진단명:</strong> {jobDetail.diagnosis}</p>
-          <p><strong>입원 목적:</strong> {jobDetail.hospitalizationPurpose}</p>
-          <p><strong>병실 유형:</strong> {jobDetail.roomType}</p>
-          <p><strong>거동 상태:</strong> {jobDetail.mobilityStatus}</p>
-          <p><strong>보조 장치 여부:</strong> {jobDetail.assistiveDevices}</p>
-          <p><strong>복용 약:</strong> {jobDetail.medications}</p>
-        </div>
-      </div>
+      <Patient      
+        id={jobDetail.id}
+        name={jobDetail.name}
+        age={jobDetail.age}
+        height={jobDetail.height}
+        weight={jobDetail.weight}
+        gender={jobDetail.gender}
+        careLocation={jobDetail.careLocation}
+        carePeriod={jobDetail.carePeriod}
+        diagnosis={jobDetail.diagnosis}
+        hospitalizationPurpose={jobDetail.hospitalizationPurpose}
+        roomType={jobDetail.roomType}
+        mobilityStatus={jobDetail.mobilityStatus}
+        assistiveDevices={jobDetail.assistiveDevices}
+        medications={jobDetail.medications}
+      />
     </div>
   );
 }

--- a/src/pages/JobSearchPage.jsx
+++ b/src/pages/JobSearchPage.jsx
@@ -1,100 +1,93 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import Bar from '../components/Bar';
+import JobCard from '../components/JobCard';
 import "../style/JobSearchPage.css";
-import userOrange from '../img/user_orange.png';
 import linkImg from "../img/link.png";
 
 function JobSearchPage() {
-  const navigate = useNavigate();
-  const [searchTerm, setSearchTerm] = useState('');
-  const [filter, setFilter] = useState({ license: '', affiliation: '', location: '' });
+    const [searchTerm, setSearchTerm] = useState('');
+    const [filter, setFilter] = useState({ license: '', affiliation: '', location: '' });
 
-  const jobCards = [
-    {
-      id: 1,
-      title: "간병사 모집",
-      author: "홍길동",
-      name: "기관",
-      license: "有",
-      affiliation: "無",
-      location: "서울 성북구"
-    },
-    {
-      id: 2,
-      title: "개인 간병사 구함",
-      author: "김철수",
-      name: "개인",
-      license: "有",
-      affiliation: "無",
-      location: "서울 노원구"
-    },
+    //db로 떼기
+    const jobCards = [
+        {
+            id: 1,
+            title: "간병사 모집",
+            author: "홍길동",
+            name: "기관",
+            license: "有",
+            affiliation: "無",
+            location: "서울 성북구"
+        },
+        {
+            id: 2,
+            title: "개인 간병사 구함",
+            author: "김철수",
+            name: "개인",
+            license: "有",
+            affiliation: "無",
+            location: "서울 노원구"
+        },
 
-  ];
+    ];
 
-  const filteredCards = jobCards.filter(card => 
-    card.name.includes(searchTerm) &&
-    (filter.license === '' || card.license === filter.license) &&
-    (filter.affiliation === '' || card.affiliation === filter.affiliation) &&
-    (filter.location === '' || card.location.includes(filter.location))
-  );
+    const filteredCards = jobCards.filter(card =>
+        card.name.includes(searchTerm) &&
+        (filter.license === '' || card.license === filter.license) &&
+        (filter.affiliation === '' || card.affiliation === filter.affiliation) &&
+        (filter.location === '' || card.location.includes(filter.location))
+    );
 
-  return (
-    <div className='jobSearchPage'>
-      <Bar />
-      <header className='header'>
-        <h1>간병인 일자리 검색</h1>
-      </header>
-      <div className='searchContainer'>
-        <input 
-          type="text" 
-          placeholder="단위 검색" 
-          className='searchBar'
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-        />
-        <div className='filters'>
-          <select onChange={(e) => setFilter({ ...filter, license: e.target.value })}>
-            <option value="">자격증</option>
-            <option value="有">있음</option>
-            <option value="無">없음</option>
-          </select>
-          <select onChange={(e) => setFilter({ ...filter, affiliation: e.target.value })}>
-            <option value="">소속</option>
-            <option value="有">있음</option>
-            <option value="無">없음</option>
-          </select>
-          <input 
-            type="text" 
-            placeholder="지역" 
-            onChange={(e) => setFilter({ ...filter, location: e.target.value })}
-          />
-        </div>
-      </div>
-      <div className='content'>
-        {filteredCards.map((card, index) => (
-          <div 
-            key={index} 
-            className='jobCard' 
-            onClick={() => navigate(`/job/${card.id}`)}
-          >
-            <div className='cardContent'>
-              <img src={userOrange} alt="user" className='userIcon' />
-              <div className='cardText'>
-                <h2>{card.title}</h2>
-                <p>작성자: {card.author}</p>
-                <p>단위: {card.name}</p>
-                <p>간병사 자격증 보유 여부: {card.license}</p>
-                <p>소속: {card.affiliation}</p>
-                <p>지역: {card.location}</p>
-              </div>
-              <img className='linkImg' src={linkImg} alt="link" />
+    return (
+        <div className='jobSearchPage'>
+            <Bar />
+            {/* 이거 실종 */}
+            <header className='header'>
+                <h1>간병인 일자리 검색</h1>
+            </header>
+            <div className='searchContainer'>
+                <input
+                    type="text"
+                    placeholder="단위 검색"
+                    className='searchBar'
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                />
+                <div className='filters'>
+                    <select onChange={(e) => setFilter({ ...filter, license: e.target.value })}>
+                        <option value="">자격증</option>
+                        <option value="有">있음</option>
+                        <option value="無">없음</option>
+                    </select>
+                    <select onChange={(e) => setFilter({ ...filter, affiliation: e.target.value })}>
+                        <option value="">소속</option>
+                        <option value="有">있음</option>
+                        <option value="無">없음</option>
+                    </select>
+                    <input
+                        type="text"
+                        placeholder="지역"
+                        onChange={(e) => setFilter({ ...filter, location: e.target.value })}
+                    />
+                </div>
             </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+            <div className='content'>
+                {filteredCards.map((card, index) => (
+                    <JobCard
+                        key={card.id}
+                        index={index}
+                        id={card.id}
+                        title={card.title} 
+                        author={card.author}
+                        name={card.name} 
+                        license={card.license} 
+                        affiliation={card.affiliation}
+                        location={card.location}
+                    />
+                ))}
+            </div>
+        </div>
+    );
 }
 
 export default JobSearchPage;


### PR DESCRIPTION
offer 컴포넌트로 따로 분리.
- 구직 게시글 카드(JobSearchPage -> JobCard)
- 환자 프로필(게시글 상세)(JobDetailPage -> Patient)

기능 변화는 없음

환자 프로필에서 이전 화면으로 돌아가는 버튼 구현 필요
구직 게시글 상세 페이지에서 본문/환자 프로필/댓글 구조로 개편 고려
더미 데이터 한 곳에 몰아두기